### PR TITLE
Updated qla2xxx module conf and enhanced SCST RA

### DIFF
--- a/etc/modprobe.conf
+++ b/etc/modprobe.conf
@@ -2,3 +2,4 @@ options ib_srpt one_target_per_port=1
 options bonding max_bonds=0
 options ocs_fc_scst initiator=1
 options zfs zfs_prefetch_disable=1
+options qla2xxx qlini_mode=disabled

--- a/etc/modprobe.conf
+++ b/etc/modprobe.conf
@@ -2,4 +2,3 @@ options ib_srpt one_target_per_port=1
 options bonding max_bonds=0
 options ocs_fc_scst initiator=1
 options zfs zfs_prefetch_disable=1
-options qla2xxx qlini_mode=disabled

--- a/misc/ocf/scst
+++ b/misc/ocf/scst
@@ -152,6 +152,19 @@ scst_stop() {
         ;;
     esac
 
+	# Demote to offline only makes sense if we are using ALUA
+    if ocf_is_true ${OCF_RESKEY_alua}; then
+        check_alua
+		# Set the local target group to the offline ALUA state
+	    ocf_log debug "scst_demote() -> Setting target group" \
+	        "'${OCF_RESKEY_local_tgt_grp}' ALUA state to" \
+	        "'offline'..."
+	    ocf_run scstadmin -noprompt -set_tgrp_attr \
+	        ${OCF_RESKEY_local_tgt_grp} -dev_group \
+	        ${OCF_RESKEY_device_group} -attributes \
+	        state\=offline || exit ${OCF_ERR_GENERIC}
+	fi
+
     # Save the SCST configuration, just in case
     ocf_log info "Saving SCST configuration..."
     if [ -f "${NO_CLOBBER}" ]; then

--- a/misc/ocf/scst
+++ b/misc/ocf/scst
@@ -243,6 +243,27 @@ scst_monitor() {
         if [ "x${tgt_grp_state}" = "x${OCF_RESKEY_m_alua_state}" ]; then
             rc=${OCF_RUNNING_MASTER}
         fi
+        
+        remote_inactive()
+        if [ $? -eq 0 ]; then
+        	# Remote does not exists, so set the remote target group to offline
+	        ocf_log debug "scst_promote() -> Setting target group" \
+	            "'${OCF_RESKEY_remote_tgt_grp}' ALUA state to" \
+	            "'offline'..."
+	        ocf_run scstadmin -noprompt -set_tgrp_attr \
+	            ${OCF_RESKEY_remote_tgt_grp} -dev_group \
+	            ${OCF_RESKEY_device_group} -attributes \
+	            state\=offline || exit ${OCF_ERR_GENERIC}
+        else  	    
+	        # Remote exists, so set the remote target group
+	        ocf_log debug "scst_promote() -> Setting target group" \
+	            "'${OCF_RESKEY_remote_tgt_grp}' ALUA state to" \
+	            "'${OCF_RESKEY_s_alua_state}'..."
+	        ocf_run scstadmin -noprompt -set_tgrp_attr \
+	            ${OCF_RESKEY_remote_tgt_grp} -dev_group \
+	            ${OCF_RESKEY_device_group} -attributes \
+	            state\=${OCF_RESKEY_s_alua_state} || exit ${OCF_ERR_GENERIC}
+        fi
     fi
 
     return ${rc}
@@ -363,6 +384,11 @@ scst_usage() {
     echo "Expects to have a fully populated OCF RA-compliant environment set."
 }
 
+remote_inactive() {
+	# determine if there is inactive(stopped) instance
+    crm_mon --as-xml | grep "resource.*id=\"${OCF_RESOURCE_INSTANCE}\".*active=\"false\"" > /dev/null 2>&1
+    return $?
+}
 
 scst_promote() {
     # Exit immediately if configuration is not valid
@@ -406,13 +432,24 @@ scst_promote() {
             ${OCF_RESKEY_device_group} -attributes \
             state\=${OCF_RESKEY_m_alua_state} || exit ${OCF_ERR_GENERIC}
         # Since there can only be one Master, set the remote target group
+        remote_inactive()
+        if [ $? -eq 0 ]; then
         ocf_log debug "scst_promote() -> Setting target group" \
             "'${OCF_RESKEY_remote_tgt_grp}' ALUA state to" \
+	            "'offline'..."
+	        ocf_run scstadmin -noprompt -set_tgrp_attr \
+	            ${OCF_RESKEY_remote_tgt_grp} -dev_group \
+	            ${OCF_RESKEY_device_group} -attributes \
+	            state\=offline || exit ${OCF_ERR_GENERIC}
+	    else
+	    	ocf_log debug "scst_promote() -> Setting target group" \
+	            "'${OCF_RESKEY_remote_tgt_grp}' ALUA state to" \
             "'${OCF_RESKEY_s_alua_state}'..."
         ocf_run scstadmin -noprompt -set_tgrp_attr \
             ${OCF_RESKEY_remote_tgt_grp} -dev_group \
             ${OCF_RESKEY_device_group} -attributes \
             state\=${OCF_RESKEY_s_alua_state} || exit ${OCF_ERR_GENERIC}
+	    fi
     else
         ocf_log err "The ALUA parameters need to be configured before using MS."
         exit ${OCF_ERR_CONFIGURED}

--- a/misc/ocf/scst
+++ b/misc/ocf/scst
@@ -156,7 +156,7 @@ scst_stop() {
     if ocf_is_true ${OCF_RESKEY_alua}; then
         check_alua
 		# Set the local target group to the offline ALUA state
-	    ocf_log debug "scst_demote() -> Setting target group" \
+	    ocf_log debug "scst_stop() -> Setting target group" \
 	        "'${OCF_RESKEY_local_tgt_grp}' ALUA state to" \
 	        "'offline'..."
 	    ocf_run scstadmin -noprompt -set_tgrp_attr \

--- a/misc/ocf/scst
+++ b/misc/ocf/scst
@@ -254,15 +254,26 @@ scst_monitor() {
 	            ${OCF_RESKEY_remote_tgt_grp} -dev_group \
 	            ${OCF_RESKEY_device_group} -attributes \
 	            state\=offline || exit ${OCF_ERR_GENERIC}
-        else  	    
-	        # Remote exists, so set the remote target group
-	        ocf_log debug "scst_promote() -> Setting target group" \
-	            "'${OCF_RESKEY_remote_tgt_grp}' ALUA state to" \
-	            "'${OCF_RESKEY_s_alua_state}'..."
-	        ocf_run scstadmin -noprompt -set_tgrp_attr \
-	            ${OCF_RESKEY_remote_tgt_grp} -dev_group \
-	            ${OCF_RESKEY_device_group} -attributes \
-	            state\=${OCF_RESKEY_s_alua_state} || exit ${OCF_ERR_GENERIC}
+        else
+        	if [ "x${tgt_grp_state}" = "x${OCF_RESKEY_m_alua_state}" ]; then
+        		# Remote exists, so set the remote target group
+		        ocf_log debug "scst_promote() -> Setting target group" \
+		            "'${OCF_RESKEY_remote_tgt_grp}' ALUA state to" \
+		            "'${OCF_RESKEY_m_alua_state}'..."
+		        ocf_run scstadmin -noprompt -set_tgrp_attr \
+		            ${OCF_RESKEY_remote_tgt_grp} -dev_group \
+		            ${OCF_RESKEY_device_group} -attributes \
+		            state\=${OCF_RESKEY_m_alua_state} || exit ${OCF_ERR_GENERIC}
+        	else  	    
+		        # Remote exists, so set the remote target group
+		        ocf_log debug "scst_promote() -> Setting target group" \
+		            "'${OCF_RESKEY_remote_tgt_grp}' ALUA state to" \
+		            "'${OCF_RESKEY_s_alua_state}'..."
+		        ocf_run scstadmin -noprompt -set_tgrp_attr \
+		            ${OCF_RESKEY_remote_tgt_grp} -dev_group \
+		            ${OCF_RESKEY_device_group} -attributes \
+		            state\=${OCF_RESKEY_s_alua_state} || exit ${OCF_ERR_GENERIC}
+		    fi
         fi
     fi
 


### PR DESCRIPTION
Updated qla2xxx module conf to prevent run qlogic cards in initiator mode. Closes #145
SCST RA Enhancement - Stop action enhanced by setting ALUA state to "offline", so initiators are not confused about nonoptimized (or other configured) state and they don't need to regroup paths to one group and then back to two. 

Signed-off-by: Kristián Feldsam <feldsam@gmail.com>